### PR TITLE
Added autostart setting

### DIFF
--- a/OPL_Server/OPLServer/Form1.cs
+++ b/OPL_Server/OPLServer/Form1.cs
@@ -45,7 +45,8 @@ namespace OPLServer
         public bool logLvlTrace = true;
         public bool logLvlVerbose = false;
         public bool logLvlWarn = true;
-        
+        public bool autoStart = false;
+
         #endregion
 
         #region Form Methods and GUI
@@ -90,6 +91,8 @@ namespace OPLServer
             }
 
             enableLog(logEnabled);
+            tsbServerState.Checked = autoStart;
+
         }
 
         private bool existArg(string arg, string[] args)
@@ -516,6 +519,8 @@ namespace OPLServer
             if (getSetting("LogWarn") == "1") { logLvlWarn = true; } else { logLvlWarn = false; }
             tsbLogWarn.Checked = logLvlWarn;
 
+            if (getSetting("AutoStart") == "1") { autoStart = true; } else { autoStart = false; }            
+
             isLoadingSettings = false;
         }
 
@@ -534,6 +539,7 @@ namespace OPLServer
             setSetting("LogTrace", logLvlTrace ? "1" : "0");
             setSetting("LogVerbose", logLvlVerbose ? "1" : "0");
             setSetting("LogWarn", logLvlWarn ? "1" : "0");
+            setSetting("AutoStart", autoStart ? "1" : "0");
         }
 
         private string getSetting(string key)


### PR DESCRIPTION
Added autostart setting for OPLServer to start as soon as it is launched.

I needed to have OPLServer autostart when launched because I wanted to run it on my home server, and it wouldn't work because it needed to be manually started by a user opening the program interactively.

The setting itself needs to be manually enabled by editing the config file, but given this is a niche, I didn't want to change the simplicity of the form.